### PR TITLE
Access consul from Armada commands by localhost instead of private Do…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+#### Improvements
+- Access Consul agent from Armada commands by localhost, instead of private Docker IP, as it sometimes causes hanging requests. 
+
 
 ## 0.7.0 (2015-08-21)
 

--- a/armada_command/consul/consul.py
+++ b/armada_command/consul/consul.py
@@ -2,7 +2,7 @@ import json
 
 import requests
 
-CONSUL_ADDRESS = '172.17.42.1:8500'
+CONSUL_ADDRESS = 'localhost:8500'
 CONSUL_TIMEOUT_IN_SECONDS = 10
 
 


### PR DESCRIPTION
…cker ip, as it sometimes causes hanging requests. Probably because of docker-proxy.