### PR TITLE
health check minor improvement

### DIFF
--- a/docker-containers/microservice/health-checks/main-port-open
+++ b/docker-containers/microservice/health-checks/main-port-open
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 check_interface() {
-    echo "checking $1 $port"
     if [[ "${port}" == */udp ]]; then
         # -v is necessary, otherwise nc always returns 0 for UDP ports.
         nc -z -u -v $1 $(cut -d/ -f1 <<< ${port})

--- a/docker-containers/microservice/health-checks/main-port-open
+++ b/docker-containers/microservice/health-checks/main-port-open
@@ -1,18 +1,28 @@
 #!/bin/bash
 
+check_interface() {
+    echo "checking $1 $port"
+    if [[ "${port}" == */udp ]]; then
+        # -v is necessary, otherwise nc always returns 0 for UDP ports.
+        nc -z -u -v $1 $(cut -d/ -f1 <<< ${port})
+    else
+        nc -z $1 ${port}
+    fi
+}
+
 port=80
 if [ -n "$1" ]; then
     port="$1"
 fi
 
-if [[ "${port}" == */udp ]]; then
-    # -v is necessary, otherwise nc always returns 0 for UDP ports.
-    nc -z -u -v 127.0.0.1 $(cut -d/ -f1 <<< ${port})
-else
-    nc -z 127.0.0.1 ${port}
-fi
+ips=`ifconfig -a|grep -w 'inet'|awk '{print $2}'|sed 's/[^0-9\.]//g'`
 
-if [ $? -eq 0 ]; then
-    exit 0
-fi
+for ip in ${ips}; do
+    check_interface ${ip}
+
+    if [ $? -eq 0 ]; then
+        exit 0
+    fi
+done
+
 exit 2


### PR DESCRIPTION
hi,

as the default health check didn’t do it for us - as our main service always binds to the non-loopback interface.
So I changed it so, that it now checks all available interfaces with assigned IP adresses and returns success as soon as it finds the given port open.

best, frank