### PR TITLE
Support http in local haproxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@
 - Upgrade Consul from version 0.6.0 to 0.6.3.
 - Run Consul using os.execv instead of spawning new process, which makes Consul's logs available in supervisor.
 - Store sorted container parameters in `/opt/armada/` on Ship, to ease checking differences between versions.
+- Allow microservices' local haproxy to forward http connections with Host header.
 
 ### Bug fixes
 - Passing `-d local` to `armada run` in Armada vagrant box does not break detection of development environment.
+- [Vagrant](https://github.com/armadaplatform/vagrant "Armada Vagrant") origin_dockyard_address parameter works properly with local dockyards by running localhost proxy. 
 
 ## 0.13.1 (2016-01-08)
 

--- a/docker-containers/microservice/src/local_magellan/haproxy.py
+++ b/docker-containers/microservice/src/local_magellan/haproxy.py
@@ -48,7 +48,7 @@ def generate_config_from_mapping(port_to_addresses):
 def _make_server_config(addresses):
     result = ""
     for i, address in enumerate(addresses):
-        protocol, host = address.split("://") if "://" in address else ("", address)
+        protocol, host = address.split("://", 2) if "://" in address else ("", address)
 
         result += '\t\tserver server_{i} {host} maxconn 128\n'.format(**locals())
         hostname = host.split(':')[0]


### PR DESCRIPTION
In order to run armada-bind as dockyard proxy we have to allow http configuration for local haproxy.