### PR TITLE
Resource limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Features
+- Introduced resource limiting parameters to `armada run` command. These parameters accept same values as their respective docker parameters.
+    - --cpu-shares 
+    - --memory 
+    - --memory-swap 
+    - --cgroup-parent
+
 ## 0.14.1 (2016-03-07)
 
 ### Bug fixes

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV ARMADA_APT_GET_UPDATE_DATE 2016-02-15
 
 RUN apt-get update
 RUN apt-get install -y python python-dev python-pip unzip rsync openssh-server
-RUN pip install -U paramiko web.py docker-py==1.7.0
+RUN pip install -U paramiko web.py docker-py==1.7.1
 
 # Consul
 RUN wget https://releases.hashicorp.com/consul/0.6.3/consul_0.6.3_linux_amd64.zip -O consul.zip

--- a/armada_backend/api_restart.py
+++ b/armada_backend/api_restart.py
@@ -30,6 +30,7 @@ class Restart(Run):
         dict_environment = restart_parameters.get('environment')
         dict_volumes = restart_parameters.get('volumes')
         run_command = restart_parameters.get('run_command')
+        docker_args = restart_parameters.get('docker_args')
         microservice_name = dict_environment.get('MICROSERVICE_NAME')
         dockyard_address, _, _ = self._split_image_path(image_path)
         docker_api = self._get_docker_api(dockyard_address, dockyard_user, dockyard_password)
@@ -51,4 +52,4 @@ class Restart(Run):
             traceback.print_exc()
 
         return self.run_container(image_path, dockyard_user, dockyard_password, dict_ports, dict_environment,
-                                  dict_volumes, run_command)
+                                  dict_volumes, run_command, docker_args)

--- a/armada_backend/api_restart.py
+++ b/armada_backend/api_restart.py
@@ -30,7 +30,7 @@ class Restart(Run):
         dict_environment = restart_parameters.get('environment')
         dict_volumes = restart_parameters.get('volumes')
         run_command = restart_parameters.get('run_command')
-        docker_args = restart_parameters.get('docker_args')
+        resource_limits = restart_parameters.get('resource_limits')
         microservice_name = dict_environment.get('MICROSERVICE_NAME')
         dockyard_address, _, _ = self._split_image_path(image_path)
         docker_api = self._get_docker_api(dockyard_address, dockyard_user, dockyard_password)
@@ -52,4 +52,4 @@ class Restart(Run):
             traceback.print_exc()
 
         return self.run_container(image_path, dockyard_user, dockyard_password, dict_ports, dict_environment,
-                                  dict_volumes, run_command, docker_args)
+                                  dict_volumes, run_command, resource_limits)

--- a/armada_backend/api_run.py
+++ b/armada_backend/api_run.py
@@ -193,7 +193,7 @@ class Run(api_base.ApiCommand):
         return run_command
 
     def __prepare_resource_limits(self, post_data):
-        docker_args = post_data.get('resource_limits')
+        docker_args = post_data.get('resource_limits', {})
         return docker_args
 
     def POST(self):

--- a/armada_backend/api_run.py
+++ b/armada_backend/api_run.py
@@ -26,7 +26,7 @@ def print_err(*objs):
 class Run(api_base.ApiCommand):
 
     def run_container(self, image_path, dockyard_user, dockyard_password, dict_ports, dict_environment, dict_volumes,
-                      run_command, docker_args):
+                      run_command, resource_limits):
         try:
             restart_parameters = {
                 'image_path': image_path,
@@ -37,7 +37,7 @@ class Run(api_base.ApiCommand):
                 'volumes': dict_volumes,
                 'run_command': run_command,
                 'microservice_name': dict_environment.get('MICROSERVICE_NAME'),
-                'docker_args': docker_args
+                'resource_limits': resource_limits
             }
             dict_environment['RESTART_CONTAINER_PARAMETERS'] = base64.b64encode(json.dumps(restart_parameters))
             dict_environment['ARMADA_RUN_COMMAND'] = base64.b64encode(run_command)
@@ -66,7 +66,7 @@ class Run(api_base.ApiCommand):
             docker_api = self._get_docker_api(dockyard_address, dockyard_user, dockyard_password)
             self._pull_latest_image(docker_api, image_path, microservice_name)
 
-            host_config = self._create_host_config(docker_api, docker_args, volume_bindings, port_bindings)
+            host_config = self._create_host_config(docker_api, resource_limits, volume_bindings, port_bindings)
             container_info = docker_api.create_container(microservice_name,
                                                          ports=ports,
                                                          environment=environment,
@@ -148,24 +148,17 @@ class Run(api_base.ApiCommand):
 
         return dockyard_address, image_name, image_tag
 
-    def _create_host_config(self, docker_api, docker_args, binds, port_bindings):
-        parser = argparse.ArgumentParser()
-        parser.add_argument('-c', '--cpu-shares', type=int)
-        parser.add_argument('-m', '--memory')
-        parser.add_argument('--memory-swap')
-        parser.add_argument('--cgroup-parent')
-        args, _ = parser.parse_known_args(docker_args)
-
+    def _create_host_config(self, docker_api, resource_limits, binds, port_bindings):
         host_config = docker_api.create_host_config(
             privileged=True,
             publish_all_ports=True,
             binds=binds,
             port_bindings=port_bindings,
-            mem_limit=args.memory,
-            memswap_limit=args.memory_swap,
-            cgroup_parent=args.cgroup_parent
+            mem_limit=resource_limits.get('memory'),
+            memswap_limit=resource_limits.get('memory_swap'),
+            cgroup_parent=resource_limits.get('cgroup_parent'),
         )
-        host_config['CpuShares'] = args.cpu_shares
+        host_config['CpuShares'] = resource_limits.get('cpu_shares')
         return host_config
 
     def __prepare_dict_ports(self, post_data):
@@ -199,8 +192,8 @@ class Run(api_base.ApiCommand):
         run_command = post_data.get('run_command')
         return run_command
 
-    def __prepare_docker_args(self, post_data):
-        docker_args = post_data.get('docker_args')
+    def __prepare_resource_limits(self, post_data):
+        docker_args = post_data.get('resource_limits')
         return docker_args
 
     def POST(self):
@@ -216,7 +209,7 @@ class Run(api_base.ApiCommand):
             dict_environment = self.__prepare_dict_environment(post_data)
             dict_volumes = self.__prepare_dict_volumes(post_data)
             run_command = self.__prepare_run_command(post_data)
-            docker_args = self.__prepare_docker_args(post_data)
+            docker_args = self.__prepare_resource_limits(post_data)
         except:
             traceback.print_exc()
             return self.status_error('API Run: Invalid input data.')

--- a/armada_backend/docker_client.py
+++ b/armada_backend/docker_client.py
@@ -10,7 +10,7 @@ class DockerException(Exception):
 
 
 def api():
-    return docker.Client(base_url='unix://' + DOCKER_SOCKET_PATH, version='1.15', timeout=7)
+    return docker.Client(base_url='unix://' + DOCKER_SOCKET_PATH, timeout=7)
 
 
 def _get_error_from_docker_pull_event(event):

--- a/armada_backend/docker_client.py
+++ b/armada_backend/docker_client.py
@@ -10,7 +10,7 @@ class DockerException(Exception):
 
 
 def api():
-    return docker.Client(base_url='unix://' + DOCKER_SOCKET_PATH, timeout=7)
+    return docker.Client(base_url='unix://' + DOCKER_SOCKET_PATH, version='1.15', timeout=7)
 
 
 def _get_error_from_docker_pull_event(event):

--- a/armada_command/command_run.py
+++ b/armada_command/command_run.py
@@ -145,9 +145,8 @@ def command_run(args):
         payload['dockyard_password'] = dockyard_info.get('password')
 
     if vagrant_dev:
-        if not args.dynamic_ports:
+        if not (args.dynamic_ports or args.publish):
             payload['ports']['4999'] = '80'
-            payload['ports']['2999'] = '22'
         if not args.use_latest_image_code:
             microservice_path = '/opt/{microservice_name}'.format(**locals())
             payload['volumes'][microservice_path] = microservice_path

--- a/armada_command/command_run.py
+++ b/armada_command/command_run.py
@@ -72,8 +72,8 @@ def add_arguments(parser):
                             config_path_base=CONFIG_PATH_BASE))
 
     # Docker args
-    parser.add_argument('-da', '--docker-args', nargs=argparse.REMAINDER, help="Docker params: -c/--cpu-shares, -m/--memory, --memory-swap")
-
+    parser.add_argument('-D', '--docker-args', nargs=argparse.REMAINDER,
+                        help="Docker params: -c/--cpu-shares, -m/--memory, --memory-swap, --cgroup-parent")
 
 
 def warn_if_hit_crontab_environment_variable_length(env_variables_dict):
@@ -93,6 +93,7 @@ def command_run(args):
     if not microservice_name:
         raise ArmadaCommandException('ERROR: Please specify microservice_name argument'
                                      ' or set MICROSERVICE_NAME environment variable')
+
     ship = args.ship
     is_run_locally = ship is None
     dockyard_alias = args.dockyard or dockyard.get_dockyard_alias(microservice_name, is_run_locally)

--- a/armada_command/command_run.py
+++ b/armada_command/command_run.py
@@ -71,6 +71,10 @@ def add_arguments(parser):
                              'If it\'s a relative path it will be mounted from {config_path_base}'.format(
                             config_path_base=CONFIG_PATH_BASE))
 
+    # Docker args
+    parser.add_argument('-da', '--docker-args', nargs=argparse.REMAINDER, help="Docker params: -c/--cpu-shares, -m/--memory, --memory-swap")
+
+
 
 def warn_if_hit_crontab_environment_variable_length(env_variables_dict):
     for env_key, env_value in env_variables_dict.items():
@@ -185,12 +189,15 @@ def command_run(args):
         run_command += ' --hidden_is_restart'
     payload['run_command'] = run_command
 
+    # --- docker_args
+    if args.docker_args:
+        payload['docker_args'] = args.docker_args
+
     # ---
     if verbose:
         print('payload: {0}'.format(payload))
 
     warn_if_hit_crontab_environment_variable_length(payload['environment'])
-
     print('Checking if there is new image version. May take few minutes if download is needed...')
     result = armada_api.post('run', payload, ship_name=ship)
 

--- a/armada_command/command_run.py
+++ b/armada_command/command_run.py
@@ -72,8 +72,10 @@ def add_arguments(parser):
                             config_path_base=CONFIG_PATH_BASE))
 
     # Docker args
-    parser.add_argument('-D', '--docker-args', nargs=argparse.REMAINDER,
-                        help="Docker params: -c/--cpu-shares, -m/--memory, --memory-swap, --cgroup-parent")
+    parser.add_argument('--cpu-shares', help="CPU shares (relative weight)", type=int)
+    parser.add_argument('--memory', help="Memory limit")
+    parser.add_argument('--memory-swap', help="Total memory (memory + swap), '-1' to disable swap")
+    parser.add_argument('--cgroup-parent', help="Optional parent cgroup for the container")
 
 
 def warn_if_hit_crontab_environment_variable_length(env_variables_dict):
@@ -190,8 +192,16 @@ def command_run(args):
     payload['run_command'] = run_command
 
     # --- docker_args
-    if args.docker_args:
-        payload['docker_args'] = args.docker_args
+    resource_limits = {}
+    if args.cpu_shares:
+        resource_limits['cpu_shares'] = args.cpu_shares
+    if args.memory:
+        resource_limits['memory'] = args.memory
+    if args.memory_swap:
+        resource_limits['memory_swap'] = args.memory_swap
+    if args.cgroup_parent:
+        resource_limits['cgroup_parent'] = args.cgroup_parent
+    payload['resource_limits'] = resource_limits
 
     # ---
     if verbose:


### PR DESCRIPTION
Initial version of resource limitations. Supports `--cpu`, `--memory`, `--memory-swap`, and `--cgroup-parent` arguments.
Because there are some differences between docker command line and python API arguments, we can't simply forward all docker arguments, without parsing and/or validation.