### PR TITLE
local haproxy binds both on IPv4 and IPv6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Features
+- Local haproxy binds both on IPv4 and IPv6.
+
 ## 0.16.1 (2016-04-04)
 
 ### Bug fixes:

--- a/docker-containers/microservice/src/local_magellan/haproxy.py
+++ b/docker-containers/microservice/src/local_magellan/haproxy.py
@@ -36,7 +36,7 @@ def generate_config_from_mapping(port_to_addresses):
     result = CONFIG_HEADER
     for port, addresses in port_to_addresses.items():
         result += '\tlisten service_{port}\n'.format(**locals())
-        result += '\t\tbind *:{port}\n'.format(**locals())
+        result += '\t\tbind :::{port} v4v6\n'.format(**locals())
         if not addresses:
             result += '\t\ttcp-request connection reject\n'
         else:


### PR DESCRIPTION
local haproxy binds both on IPv4 and IPv6