### PR TITLE
fix passing arguments to 'armada ssh'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ mounted from local workstation.
 - Moved armada installation script from [armada-website](https://github.com/armadaplatform/armada-website) repository to armada repository.
 - Added OpenRC support (Contributed by [ryneeverett](https://github.com/ryneeverett)).
 
+### Bug fixes
+- Fixed issue with passing arguments to `armada ssh`.
+
 ## 0.18.0 (2016-05-09)
 ### Features
 - Services can now be moved between ships in a cluster with `armada restart` command using `--ship` parameter.

--- a/armada_command/command_ssh.py
+++ b/armada_command/command_ssh.py
@@ -1,6 +1,8 @@
 from __future__ import print_function
 
 import argparse
+import shlex
+import pipes
 import os
 
 import armada_utils
@@ -48,10 +50,6 @@ def command_ssh(args):
     if container_id in local_microservices_ids:
         is_local = True
 
-    if not is_local:
-        ssh_host = instance['Address']
-        docker_key_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'keys/docker.key')
-
     if args.command:
         command = ' '.join(args.command)
     else:
@@ -63,14 +61,20 @@ def command_ssh(args):
     interactive = '-i' if args.interactive else ''
     term = os.environ.get('TERM') or 'dummy'
 
-    ssh_command = 'docker exec {interactive} {tty} {container_id} env TERM={term} {command}'.format(**locals())
+    command = pipes.quote(command)
+    docker_command = 'docker exec {interactive} {tty} {container_id} env TERM={term} ' \
+                     'sh -c {command}'.format(**locals())
 
     if is_local:
         print("Connecting to {0}...".format(instance['ServiceName']))
+        ssh_args = shlex.split(docker_command)
     else:
-        ssh_command = 'ssh -t {tty} -p 2201 -i {docker_key_file} -o StrictHostKeyChecking=no docker@{ssh_host} sudo {ssh_command}'.format(
-                **locals())
+        ssh_host = instance['Address']
+        docker_key_file = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'keys/docker.key')
+        remote_ssh_chunk = 'ssh -t {tty} -p 2201 -i {docker_key_file} -o StrictHostKeyChecking=no docker@{ssh_host}'\
+            .format(**locals())
+        ssh_args = shlex.split(remote_ssh_chunk)
+        ssh_args.extend(('sudo', docker_command))
         print("Connecting to {0} on host {1}...".format(instance['ServiceName'], ssh_host))
 
-    ssh_args = ssh_command.split()
     os.execvp(ssh_args[0], ssh_args)


### PR DESCRIPTION
This fixes issue with calling commands like:

    armada ssh example ls -la /var/log/supervisor/example*.log
    armada ssh example 'python -c "print(123); print(456)"'