### PR TITLE
Configurable configs mount point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased
 
 ### Improvements
+- Optionally restrict possible config directories. By default root directory is mounted in read-only mode.
+This can be restricted by setting `RESTRICT_CUSTOM_CONFIG_DIRS` variable to a specific path. (e.g. /home/user/configs)
+
 - `run` and `restart` commands can get IP address as '--ship' argument.
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 ### Improvements
-- Optionally restrict possible config directories. By default root directory is mounted in read-only mode.
+- Optionally restrict possible config directories. By default root directory is mounted inside armada container in read-only mode, to verify existence of `--config` paths.
 This can be restricted by setting `RESTRICT_CUSTOM_CONFIG_DIRS` variable to a specific path. (e.g. /home/user/configs)
 
 - `run` and `restart` commands can get IP address as '--ship' argument.

--- a/armada_backend/api_run_hermes.py
+++ b/armada_backend/api_run_hermes.py
@@ -3,7 +3,7 @@ import os
 
 CONFIGS_CUSTOM_DIR = '/configs'
 CONFIG_PATH_BASE = '/etc/opt/'
-HOST_CONFIG_DIR = os.environ.get('HOST_CONFIG_DIR')
+RESTRICT_CUSTOM_CONFIG_DIRS = os.environ.get('RESTRICT_CUSTOM_CONFIG_DIRS')
 
 class Volumes(object):
     def __init__(self):
@@ -18,8 +18,8 @@ class Volumes(object):
     def get_existing_volumes(self):
         used = set()
         for volume in self.volumes:
-            if volume[0].startswith("/") and not volume[0].startswith(HOST_CONFIG_DIR):
-                raise Exception("{0} is outside of allowed config mount points. ({1})".format(volume[0], HOST_CONFIG_DIR))
+            if not (volume[0].startswith(CONFIG_PATH_BASE) or volume[0].startswith(RESTRICT_CUSTOM_CONFIG_DIRS)):
+                raise Exception("{0} is outside of allowed config mount points. ({1})".format(volume[0], RESTRICT_CUSTOM_CONFIG_DIRS))
             if _is_directory(volume[0], root_path=CONFIGS_CUSTOM_DIR) and volume[1] not in used:
                 used.add(volume[1])
                 yield volume

--- a/armada_backend/api_run_hermes.py
+++ b/armada_backend/api_run_hermes.py
@@ -3,7 +3,7 @@ import os
 
 CONFIGS_CUSTOM_DIR = '/configs'
 CONFIG_PATH_BASE = '/etc/opt/'
-
+HOST_CONFIG_DIR = os.environ.get('HOST_CONFIG_DIR')
 
 class Volumes(object):
     def __init__(self):
@@ -11,12 +11,15 @@ class Volumes(object):
 
     def add_config_paths(self, config_paths):
         for config_path in config_paths:
+            # os.path.join ignores CONFIG_PATH_BASE if config_path is an absolute path!
             volume_mapping = (os.path.join(CONFIG_PATH_BASE, config_path),) * 2
             self.volumes.append(volume_mapping)
 
     def get_existing_volumes(self):
         used = set()
         for volume in self.volumes:
+            if volume[0].startswith("/") and not volume[0].startswith(HOST_CONFIG_DIR):
+                raise Exception("{0} is outside of allowed config mount points. ({1})".format(volume[0], HOST_CONFIG_DIR))
             if _is_directory(volume[0], root_path=CONFIGS_CUSTOM_DIR) and volume[1] not in used:
                 used.add(volume[1])
                 yield volume

--- a/armada_backend/api_run_hermes.py
+++ b/armada_backend/api_run_hermes.py
@@ -1,7 +1,7 @@
 import itertools
 import os
 
-SHIP_ROOT_DIR = '/ship_root_dir'
+CONFIGS_CUSTOM_DIR = '/configs'
 CONFIG_PATH_BASE = '/etc/opt/'
 
 
@@ -17,7 +17,7 @@ class Volumes(object):
     def get_existing_volumes(self):
         used = set()
         for volume in self.volumes:
-            if _is_directory(volume[0], root_path=SHIP_ROOT_DIR) and volume[1] not in used:
+            if _is_directory(volume[0], root_path=CONFIGS_CUSTOM_DIR) and volume[1] not in used:
                 used.add(volume[1])
                 yield volume
 

--- a/armada_backend/api_run_hermes.py
+++ b/armada_backend/api_run_hermes.py
@@ -12,16 +12,17 @@ class Volumes(object):
     def add_config_paths(self, config_paths):
         for config_path in config_paths:
             # os.path.join ignores CONFIG_PATH_BASE if config_path is an absolute path!
-            volume_mapping = (os.path.join(CONFIG_PATH_BASE, config_path),) * 2
-            self.volumes.append(volume_mapping)
+            volume_path = os.path.join(CONFIG_PATH_BASE, config_path)
+            self.volumes.append(volume_path)
 
     def get_existing_volumes(self):
         used = set()
         for volume in self.volumes:
-            if not (volume[0].startswith(CONFIG_PATH_BASE) or volume[0].startswith(RESTRICT_CUSTOM_CONFIG_DIRS)):
-                raise Exception("{0} is outside of allowed config mount points. ({1})".format(volume[0], RESTRICT_CUSTOM_CONFIG_DIRS))
-            if _is_directory(volume[0], root_path=CONFIGS_CUSTOM_DIR) and volume[1] not in used:
-                used.add(volume[1])
+            if not (volume.startswith(CONFIG_PATH_BASE) or volume.startswith(RESTRICT_CUSTOM_CONFIG_DIRS)):
+                raise Exception("{0} is outside of allowed config mount points. ({1}, {2})".
+                                format(volume, CONFIG_PATH_BASE, RESTRICT_CUSTOM_CONFIG_DIRS))
+            if _is_directory(volume, root_path=CONFIGS_CUSTOM_DIR) and volume not in used:
+                used.add(volume)
                 yield volume
 
 
@@ -98,12 +99,9 @@ def process_hermes(microservice_name, image_name, env, app_id, configs):
 
     volumes = Volumes()
     volumes.add_config_paths(possible_config_paths)
+    existing_volumes = volumes.get_existing_volumes()
 
-    hermes_volumes = {}
-
-    config_path = os.pathsep.join(volume[1] for volume in volumes.get_existing_volumes())
-
-    for volume in volumes.get_existing_volumes():
-        hermes_volumes[volume[0]] = volume[1]
+    config_path = os.pathsep.join(existing_volumes)
+    hermes_volumes = {volume: volume for volume in existing_volumes}
 
     return config_path, hermes_volumes

--- a/install/armada-runner
+++ b/install/armada-runner
@@ -8,6 +8,8 @@ ARMADA_LOCK_FILE=/var/lock/subsys/$BASE
 ARMADA_DESC="armada"
 ARMADA_PORT=8900
 
+CONFIGS_CUSTOM_DIR=/etc
+
 DOCKER_PID_FILE='/var/run/docker.pid'
 
 PATH=$PATH:/usr/local/bin
@@ -143,7 +145,7 @@ case "$1" in
             -v /etc/opt:/etc/opt \
             -v /opt/armada-docker-client/docker-$docker_version:/usr/bin/docker \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -v /:/ship_root_dir:ro \
+            -v $CONFIGS_CUSTOM_DIR:/configs:ro \
             -e SHIP_EXTERNAL_IP=${external_ip} \
             -e MICROSERVICE_NAME=armada \
             -e DOCKER_START_TIMESTAMP=${docker_start_timestamp}"

--- a/install/armada-runner
+++ b/install/armada-runner
@@ -8,7 +8,7 @@ ARMADA_LOCK_FILE=/var/lock/subsys/$BASE
 ARMADA_DESC="armada"
 ARMADA_PORT=8900
 
-CONFIGS_CUSTOM_DIR=/etc
+RESTRICT_CUSTOM_CONFIG_DIRS=/
 
 DOCKER_PID_FILE='/var/run/docker.pid'
 
@@ -145,11 +145,11 @@ case "$1" in
             -v /etc/opt:/etc/opt \
             -v /opt/armada-docker-client/docker-$docker_version:/usr/bin/docker \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -v ${CONFIGS_CUSTOM_DIR}:/configs:ro \
+            -v ${RESTRICT_CUSTOM_CONFIG_DIRS}:/configs:ro \
             -e SHIP_EXTERNAL_IP=${external_ip} \
             -e MICROSERVICE_NAME=armada \
             -e DOCKER_START_TIMESTAMP=${docker_start_timestamp} \
-            -e HOST_CONFIG_DIR=${CONFIGS_CUSTOM_DIR}"
+            -e RESTRICT_CUSTOM_CONFIG_DIRS=${RESTRICT_CUSTOM_CONFIG_DIRS}"
 
         if [ "$ARMADA_AUTORELOAD" == "true" ]; then
             run_options+=" -v /opt/armada-src/armada_backend:/opt/armada-docker/armada_backend -e ARMADA_AUTORELOAD=true"

--- a/install/armada-runner
+++ b/install/armada-runner
@@ -145,10 +145,11 @@ case "$1" in
             -v /etc/opt:/etc/opt \
             -v /opt/armada-docker-client/docker-$docker_version:/usr/bin/docker \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -v $CONFIGS_CUSTOM_DIR:/configs:ro \
+            -v ${CONFIGS_CUSTOM_DIR}:/configs:ro \
             -e SHIP_EXTERNAL_IP=${external_ip} \
             -e MICROSERVICE_NAME=armada \
-            -e DOCKER_START_TIMESTAMP=${docker_start_timestamp}"
+            -e DOCKER_START_TIMESTAMP=${docker_start_timestamp} \
+            -e HOST_CONFIG_DIR=${CONFIGS_CUSTOM_DIR}"
 
         if [ "$ARMADA_AUTORELOAD" == "true" ]; then
             run_options+=" -v /opt/armada-src/armada_backend:/opt/armada-docker/armada_backend -e ARMADA_AUTORELOAD=true"


### PR DESCRIPTION
Instead of mounting entire directory, we should be able to specify mount point for services' config files. As default '/etc' is used. 
In default configuration, using a config directory outside of `/etc` scope, (e.g. /home/karamazi/service-config) will silently fail.