### PR TITLE
Stop register_in_service_discovery process on old microservices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+- Ensure services based on old `microservice` image do not register themselves back in Consul during `armada stop`.
+
+
 ## 1.5.2 (2016-09-09)
 
 We do best effort to support docker versions 1.6.0 - 1.12.0 with this release.

--- a/armada_backend/utils.py
+++ b/armada_backend/utils.py
@@ -115,7 +115,6 @@ def get_local_containers_ids():
     return list(set(service['container_id'] for service in services_from_api if service['status'] not in ['recovering',
                                                                                                           'crashed']))
 
-
 def is_container_running(container_id):
     docker_api = docker_client.api()
     try:
@@ -123,3 +122,12 @@ def is_container_running(container_id):
         return inspect['State']['Running']
     except:
         return False
+
+
+def run_command_in_container(command, container_id):
+    docker_api = docker_client.api()
+    try:
+        exec_id = docker_api.exec_create(container_id, command)
+        docker_api.exec_start(exec_id['Id'])
+    except:
+        traceback.print_exc()

--- a/docker-containers/microservice/Dockerfile
+++ b/docker-containers/microservice/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:14.04
 MAINTAINER Cerebro <cerebro@ganymede.eu>
 
 # You can force apt-get update & upgrade on next 'armada build' by changing the date:
-ENV MICROSERVICE_APT_GET_UPDATE_DATE 2016-05-18
+ENV MICROSERVICE_APT_GET_UPDATE_DATE 2016-09-16
 
 # 'sync' is to fix "text file busy" error.
 ADD . /opt/microservice


### PR DESCRIPTION
Resolves https://github.com/armadaplatform/armada/issues/121
Old microservice images could re-register themselves in consul during `docker stop` API call.