### PR TITLE
Read health-check from old log file if new one is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 ### Features
 - Storing service restart parameters and status in K/V store.
-    - `armada recover` by default will try recover crashed services from K/V store
+- `armada recover` by default will try recover crashed services from K/V store
 
 ### Improvements
 - Ship names survive joining armada
 - Ship names must be unique
+- `armada diagnose` properly prints last health-check for services based on old microservice image, along with deprecation warning. 
 
 
 ## 1.5.3 (2016-09-20)

--- a/armada_command/diagnostic_scripts/diagnose.sh
+++ b/armada_command/diagnostic_scripts/diagnose.sh
@@ -34,7 +34,7 @@ echo -e "\n${cyan}Available hermes configs ${NC}"
 cd /etc/opt ; find -L . -maxdepth 1 -type d | sort
 
 echo -e "\n${green}Last health check ${NC}"
-cat /var/log/supervisor/armada_agent-stderr*log | grep "$(cat /var/log/supervisor/armada_agent-stderr*log | grep '^=== START: ' | tail -n1)" -A 100
+cat /var/log/supervisor/armada_agent-stderr*log 2> /dev/null | grep "$(cat /var/log/supervisor/armada_agent-stderr*log 2> /dev/null | grep '^=== START: ' | tail -n1)" -A 100
 if [ $? -ne 0 ]; then
     cat /var/log/supervisor/run_health_checks-stderr*log | grep "$(cat /var/log/supervisor/run_health_checks-stderr*log | grep '^=== START: ' | tail -n1)" -A 100
 fi

--- a/armada_command/diagnostic_scripts/diagnose.sh
+++ b/armada_command/diagnostic_scripts/diagnose.sh
@@ -35,6 +35,9 @@ cd /etc/opt ; find -L . -maxdepth 1 -type d | sort
 
 echo -e "\n${green}Last health check ${NC}"
 cat /var/log/supervisor/armada_agent-stderr*log | grep "$(cat /var/log/supervisor/armada_agent-stderr*log | grep '^=== START: ' | tail -n1)" -A 100
+if [ $? -ne 0 ]; then
+    cat /var/log/supervisor/run_health_checks-stderr*log | grep "$(cat /var/log/supervisor/run_health_checks-stderr*log | grep '^=== START: ' | tail -n1)" -A 100
+fi
 
 echo -e "\n${purple}Process tree ${NC}"
 ps -auxf

--- a/armada_command/diagnostic_scripts/diagnose.sh
+++ b/armada_command/diagnostic_scripts/diagnose.sh
@@ -36,6 +36,7 @@ cd /etc/opt ; find -L . -maxdepth 1 -type d | sort
 echo -e "\n${green}Last health check ${NC}"
 cat /var/log/supervisor/armada_agent-stderr*log 2> /dev/null | grep "$(cat /var/log/supervisor/armada_agent-stderr*log 2> /dev/null | grep '^=== START: ' | tail -n1)" -A 100
 if [ $? -ne 0 ]; then
+    echo -e "\n${red}Deprecation warning: Your service is based on old microservice image. Consider rebuilding it with '-d armada' parameter.${NC}"
     cat /var/log/supervisor/run_health_checks-stderr*log | grep "$(cat /var/log/supervisor/run_health_checks-stderr*log | grep '^=== START: ' | tail -n1)" -A 100
 fi
 


### PR DESCRIPTION
When diagnosing services based on old microservice image, last health check is not shown due to different log file.