### PR TITLE
Fix getting docker version with docker 18

### DIFF
--- a/armada_command/dockyard/alias.py
+++ b/armada_command/dockyard/alias.py
@@ -38,7 +38,7 @@ work-around and access it by running proxy service:
 
 def get_docker_server_version():
     # Tested for versions 1.3.0 - 1.10.0
-    cmd = 'docker version | grep -i server -A1 | grep -i version | head -n1 | cut -d: -f2'
+    cmd = 'docker version | grep -i server -A2 | grep -i version | head -n1 | cut -d: -f2'
     return subprocess.check_output(cmd, shell=True).strip()
 
 

--- a/packaging/bin/armada-runner
+++ b/packaging/bin/armada-runner
@@ -48,17 +48,17 @@ set_external_ip() {
         if [[ -z "$default_interface" ]]; then
             default_interface='lo'
         fi
-    fi  
+    fi
     # check if interface really exists
-    if [[ "$default_interface" != "lo" ]] && ! ( ip r | grep $default_interface -wq ); then 
-        log_message "ERROR: Interface $default_interface is unplugged or misspelled. Check your devices or change default settings in /etc/default/armada (default_interface=YOUR_INTERFACE_NAME) or comment it to enable autodetection."; 
-        exit 1; 
+    if [[ "$default_interface" != "lo" ]] && ! ( ip r | grep $default_interface -wq ); then
+        log_message "ERROR: Interface $default_interface is unplugged or misspelled. Check your devices or change default settings in /etc/default/armada (default_interface=YOUR_INTERFACE_NAME) or comment it to enable autodetection.";
+        exit 1;
     fi
     # reading ip address
     external_ip=$( ip address show $default_interface 2>&1 | awk '/inet/&&!/inet6/{split($2,a,"/");print a[1]}' )
     # check ip format
     if [[ -z "$( echo $external_ip | awk '{match($0,/[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+/);ip=substr($0,RSTART,RLENGTH);print ip}')" ]]; then
-        log_message "ERROR: Wrong ip format -> \"$external_ip\". Maybe ip command problem." 
+        log_message "ERROR: Wrong ip format -> \"$external_ip\". Maybe ip command problem."
         exit 1
     fi
     log_message "Binding this network device: $default_interface/$external_ip"
@@ -125,7 +125,7 @@ stop_armada() {
 }
 
 docker_server_version() {
-    echo $(docker version | grep -i server -A1 | grep -i version | head -n1 | cut -d: -f2)
+    echo $(docker version | grep -i server -A2 | grep -i version | head -n1 | cut -d: -f2)
 }
 
 get_static_docker_client_if_missing() {


### PR DESCRIPTION
Docker 18 adds Engine line before printing Version. This should fix it.