### PR TITLE
Fix netcat version for ArchLinux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+- Fix netcat version on ArchLinux
+
 ## 2.6.0 (2018-03-09)
 
 We do best effort to support docker versions 1.12.0 - 17.12.1 with this release.

--- a/packaging/build_armada.py
+++ b/packaging/build_armada.py
@@ -104,7 +104,7 @@ def create_amazon_linux_package(version):
 def create_pacman_package(version):
     deb = {
         'package_type': 'pacman',
-        'depends': ['python2', 'python2-pip', 'conntrack-tools', 'iproute2', 'jq', 'gnu-netcat'],
+        'depends': ['python2', 'python2-pip', 'conntrack-tools', 'iproute2', 'jq', 'openbsd-netcat'],
         'suggests': ['python2-pyaudio'],
     }
     packaging_options = defaults.copy()


### PR DESCRIPTION
It seems that you use openbsd version of netcat, as in gnu version there is no -U option...
sorry for my mistake with last pull :)